### PR TITLE
chore: fixed start scripts and added PR guideline docs

### DIFF
--- a/PULL_REQUEST_GUIDELINES.md
+++ b/PULL_REQUEST_GUIDELINES.md
@@ -1,0 +1,5 @@
+#Pull Request Guidelines
+
+- Minimum of 2 reviewers
+- { lower case change type}: {name of change}
+- Shorter descriptions that describe what is being changed/added, includes what kind of change it adds and to what part(s) of the application it adds to

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "react-scripts": "3.4.1"
   },
   "scripts": {
-    "start": "craco start",
-    "build": "craco build",
+    "start": "react-scripts --max_old_space_size=4096 start",
+    "build": "react-scripts --max_old_space_size=4096 build",
     "test": "craco test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject",
     "prettier": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",


### PR DESCRIPTION
Changed the start and build script in package.json to include the  --max_old_space_size={number here} flag to avoid the JS memory heaps error on Windows. Also added a PR guideline file in the root directory.