### PR TITLE
Chore: fix sizing on hamburger and menu items

### DIFF
--- a/src/components/common/AppHeader.js
+++ b/src/components/common/AppHeader.js
@@ -18,7 +18,7 @@ const StyledHeader = styled(Header)`
     width: 35%;
   }
   .hamburger-menu {
-    font-size: 2rem;
+    font-size: 4rem;
   }
 `;
 

--- a/src/components/common/AppMenu.js
+++ b/src/components/common/AppMenu.js
@@ -8,6 +8,10 @@ const { Item, ItemGroup } = Menu;
 const StyledMenu = styled(Menu)`
   position: fixed;
   top: 75px;
+
+  .link-to {
+    font-size: 1.6rem;
+  }
 `;
 
 function AppMenu() {
@@ -18,19 +22,29 @@ function AppMenu() {
     <StyledMenu className="menu toggle-menu" onClick={handleClick}>
       <ItemGroup title="SaverLife">
         <Item>
-          <Link to="/categories">categories component</Link>
+          <Link className="link-to" to="/categories">
+            categories component
+          </Link>
         </Item>
         <Item>
-          <Link to="/budget">budget component</Link>
+          <Link className="link-to" to="/budget">
+            budget component
+          </Link>
         </Item>
         <Item>
-          <Link to="/profile">profile component</Link>
+          <Link className="link-to" to="/profile">
+            profile component
+          </Link>
         </Item>
         <Item>
-          <Link to="/progress">progress component</Link>
+          <Link className="link-to" to="/progress">
+            progress component
+          </Link>
         </Item>
         <Item>
-          <Link to="/transactions">transactions component</Link>
+          <Link className="link-to" to="/transactions">
+            transactions component
+          </Link>
         </Item>
       </ItemGroup>
       {/* </SubMenu> */}


### PR DESCRIPTION
When we changed the universal font size to 62.5%, we ended up affecting the hamburger icon and menu items. This PR fixes this. Moving forward everybody will have the correct font size. No Trello card, quick fix!