### PR TITLE
Uncomment out code that breaks graphs using transactions

### DIFF
--- a/src/state/reducers/transactionReducer.js
+++ b/src/state/reducers/transactionReducer.js
@@ -1,4 +1,3 @@
-/*
 const initialState = {
   data: [
     {
@@ -465,10 +464,10 @@ const initialState = {
     },
   ],
 };
-*/
-const initialState = {
-  data: [],
-};
+
+// const initialState = {
+//   data: [],
+// };
 
 export const transactionReducer = (state = initialState, action) => {
   switch (action.type) {


### PR DESCRIPTION
There is dummy data that must remain in place for the app to compile as long as we have our transaction plots. When we hook up transaction data from the backend successfully, we can remove this code.