### PR TITLE
chore: rerouting "get started page" and "dashboard" through a redirect

### DIFF
--- a/src/components/pages/Landing/LandingPage.js
+++ b/src/components/pages/Landing/LandingPage.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useOktaAuth } from '@okta/okta-react';
+import { Redirect } from 'react-router-dom';
 import {
   MainContainerWrapper,
   LoginButton,
@@ -33,125 +35,132 @@ import {
 } from './style';
 
 const LandingPage = () => {
+  const { authState, authService } = useOktaAuth();
   return (
     <>
-      <MainContainerWrapper>
-        {/* Top Header */}
-        <WrapperRow>
-          <LoginLink to="/login">
-            <LoginButton>Log In</LoginButton>
-          </LoginLink>
-          <MainLogo />
-        </WrapperRow>
+      {authState.isAuthenticated ? (
+        <Redirect exact to="/dashboard" />
+      ) : (
+        <MainContainerWrapper>
+          {/* Top Header */}
+          <WrapperRow>
+            <LoginLink to="/login">
+              <LoginButton>Log In</LoginButton>
+            </LoginLink>
+            <MainLogo />
+          </WrapperRow>
 
-        <WrapperColumnPurple>
-          <PiggyBank />
-          <Header>
-            SaverLife is a nonprofit that helps you build financial security.
-          </Header>
-          <Para>
-            Our mission is to make saving money easier and more rewarding. We
-            receive donations to give you cash rewards and prizes for building
-            up your rainy day fund!
-          </Para>
-        </WrapperColumnPurple>
-        <WrapperColumn>
-          <HeaderPurple>How It Works</HeaderPurple>
-          <WrapperRow>
-            <LinkImg />
-            <FlexDiv>
-              <Header3>Link your account</Header3>
-              <ParaBlack>
-                SaverLife is not a bank and doesn’t touch your money. Link your
-                existing bank account where you save.
-              </ParaBlack>
-            </FlexDiv>
-          </WrapperRow>
-          <TitleDivider />
-          <WrapperRow>
-            <FlexDiv>
-              <Header3>Earn points</Header3>
-              <ParaBlack>
-                Earn points as you build your financial health. Read articles,
-                use our budgeting tools, and save money.
-              </ParaBlack>
-            </FlexDiv>
-            <EarnImg />
-          </WrapperRow>
-          <TitleDivider />
-          <WrapperRow>
-            <RewardImg />
-            <FlexDiv>
-              <Header3>Get rewarded</Header3>
-              <ParaBlack>
-                Redeem your points for digital prizes or a chance to win cash!
-              </ParaBlack>
-            </FlexDiv>
-          </WrapperRow>
-          <WrapperColumnPurple2>
-            <HeaderBlue>Why We're Here</HeaderBlue>
-            <BrokeImg />
-            <HeaderBlue2>
-              4 out of 10 Americans have less than $400 in savings. Millions
-              live paycheck to paycheck.*
-            </HeaderBlue2>
-            <ParaBlue>
-              It can be extremely hard to save money when you’re constantly
-              paying off debt, medical bills, and other unplanned expenses.
-              Especially in a world where everything is screaming ‘buy me, buy
-              me, buy me’. SaverLife is here to help you navigate the ins and
-              outs of managing your money.
-            </ParaBlue>
-          </WrapperColumnPurple2>
+          <WrapperColumnPurple>
+            <PiggyBank />
+            <Header>
+              SaverLife is a nonprofit that helps you build financial security.
+            </Header>
+            <Para>
+              Our mission is to make saving money easier and more rewarding. We
+              receive donations to give you cash rewards and prizes for building
+              up your rainy day fund!
+            </Para>
+          </WrapperColumnPurple>
           <WrapperColumn>
-            <HeaderPurple>Testimonials</HeaderPurple>
-            <TestimonialDiv>
-              <Testimonial1 />
-              <TitleDivider2 />
-              <ParaBlack>
-                "I was so excited when I saw I won! I thought it was a joke at
-                first, but I really did win!"
-              </ParaBlack>
+            <HeaderPurple>How It Works</HeaderPurple>
+            <WrapperRow>
+              <LinkImg />
               <FlexDiv>
-                <Captions> -Tracy, $50 winner from Texas</Captions>
+                <Header3>Link your account</Header3>
+                <ParaBlack>
+                  SaverLife is not a bank and doesn’t touch your money. Link
+                  your existing bank account where you save.
+                </ParaBlack>
               </FlexDiv>
-            </TestimonialDiv>
-            <TestimonialDiv>
-              <Testimonial2 />
-              <TitleDivider2 />
-              <ParaBlack>
-                "I am a walking testimony that the program works, the program is
-                real, and you DO save."
-              </ParaBlack>
+            </WrapperRow>
+            <TitleDivider />
+            <WrapperRow>
               <FlexDiv>
-                <Captions>-Jessica, $5,000 winner from South Carolina</Captions>
+                <Header3>Earn points</Header3>
+                <ParaBlack>
+                  Earn points as you build your financial health. Read articles,
+                  use our budgeting tools, and save money.
+                </ParaBlack>
               </FlexDiv>
-            </TestimonialDiv>
-            <TestimonialDiv>
-              <Testimonial3 />
-              <TitleDivider2 />
-              <ParaBlack>
-                "I was so excited when I won! I just clicked on it and i
-                couldn't believe it. The SaverLife site is really helpful."
-              </ParaBlack>
+              <EarnImg />
+            </WrapperRow>
+            <TitleDivider />
+            <WrapperRow>
+              <RewardImg />
               <FlexDiv>
-                <Captions> -Lucinda, $50 winner from Arizona</Captions>
+                <Header3>Get rewarded</Header3>
+                <ParaBlack>
+                  Redeem your points for digital prizes or a chance to win cash!
+                </ParaBlack>
               </FlexDiv>
-            </TestimonialDiv>
+            </WrapperRow>
+            <WrapperColumnPurple2>
+              <HeaderBlue>Why We're Here</HeaderBlue>
+              <BrokeImg />
+              <HeaderBlue2>
+                4 out of 10 Americans have less than $400 in savings. Millions
+                live paycheck to paycheck.*
+              </HeaderBlue2>
+              <ParaBlue>
+                It can be extremely hard to save money when you’re constantly
+                paying off debt, medical bills, and other unplanned expenses.
+                Especially in a world where everything is screaming ‘buy me, buy
+                me, buy me’. SaverLife is here to help you navigate the ins and
+                outs of managing your money.
+              </ParaBlue>
+            </WrapperColumnPurple2>
+            <WrapperColumn>
+              <HeaderPurple>Testimonials</HeaderPurple>
+              <TestimonialDiv>
+                <Testimonial1 />
+                <TitleDivider2 />
+                <ParaBlack>
+                  "I was so excited when I saw I won! I thought it was a joke at
+                  first, but I really did win!"
+                </ParaBlack>
+                <FlexDiv>
+                  <Captions> -Tracy, $50 winner from Texas</Captions>
+                </FlexDiv>
+              </TestimonialDiv>
+              <TestimonialDiv>
+                <Testimonial2 />
+                <TitleDivider2 />
+                <ParaBlack>
+                  "I am a walking testimony that the program works, the program
+                  is real, and you DO save."
+                </ParaBlack>
+                <FlexDiv>
+                  <Captions>
+                    -Jessica, $5,000 winner from South Carolina
+                  </Captions>
+                </FlexDiv>
+              </TestimonialDiv>
+              <TestimonialDiv>
+                <Testimonial3 />
+                <TitleDivider2 />
+                <ParaBlack>
+                  "I was so excited when I won! I just clicked on it and i
+                  couldn't believe it. The SaverLife site is really helpful."
+                </ParaBlack>
+                <FlexDiv>
+                  <Captions> -Lucinda, $50 winner from Arizona</Captions>
+                </FlexDiv>
+              </TestimonialDiv>
+            </WrapperColumn>
           </WrapperColumn>
-        </WrapperColumn>
 
-        <Footer>
-          Icons made by{' '}
-          <a href="https://www.flaticon.com/authors/freepik" title="Freepik">
-            Freepik
-          </a>{' '}
-          from{' '}
-          <a href="https://www.flaticon.com/" title="Flaticon">
-            www.flaticon.com
-          </a>
-        </Footer>
-      </MainContainerWrapper>
+          <Footer>
+            Icons made by{' '}
+            <a href="https://www.flaticon.com/authors/freepik" title="Freepik">
+              Freepik
+            </a>{' '}
+            from{' '}
+            <a href="https://www.flaticon.com/" title="Flaticon">
+              www.flaticon.com
+            </a>
+          </Footer>
+        </MainContainerWrapper>
+      )}
     </>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -58,10 +58,10 @@ function App() {
         <Route path="/login" component={LoginPage} />
         <Route path="/signup" component={OnboardingFlow} />
         <Route path="/implicit/callback" component={LoginCallback} />
-        <Route path="/get-started" component={LandingPage} />
+        <Route exact path="/" component={LandingPage} />
         {/* any of the routes you need secured should be registered as SecureRoutes */}
         <SecureRoute
-          path="/"
+          path="/dashboard"
           exact
           component={() => <HomePage LoadingComponent={LoadingComponent} />}
         />


### PR DESCRIPTION
https://trello.com/c/32XaLpuE/57-react-routing-and-redirect-start-on-the-informational-page-login-to-the-dashboard

- App now redirects to SaverLife informational page
- App will redirect to the informational page whenever somebody is not logged in
- App will skip over the informational page when you are logged in.